### PR TITLE
fix rabbitmq hostname

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
         enable_lazy_load_no_trans: true
 
   rabbitmq:
-    host: localhost
+    host: rabbitmq
     port: 5672
 
 routing-key:
@@ -29,5 +29,3 @@ keycloak:
   auth-server-url: http://127.0.0.1:8080/
   resource: spring-app
   bearer-only: true
-
-


### PR DESCRIPTION
fix rabbitmq hostname after SOMEONE changed it to localhost